### PR TITLE
Specify this as an add-on server

### DIFF
--- a/lsp-tailwindcss.el
+++ b/lsp-tailwindcss.el
@@ -54,7 +54,7 @@
   (message "lsp-tailwindcss callback %s" workspace))
 
 (defun lsp-tailwindcss--install-server (client callback error-callback update?)
-  (if (and (not udpate?) lsp-tailwindcss-server-installed-p)
+  (if (and (not update?) lsp-tailwindcss-server-installed-p)
       (lsp--info "tailwindcss language server already installed.")
     (let ((remote lsp-tailwindcss-server-remote)
           (local lsp-tailwindcss-server-dir)

--- a/lsp-tailwindcss.el
+++ b/lsp-tailwindcss.el
@@ -81,6 +81,7 @@
   :major-modes '(web-mode css-mode html-mode)
   :server-id 'tailwindcss
   :priority -1
+  :add-on? t
   :notification-handlers (lsp-ht ("tailwindcss/configUpdated" 'lsp-tailwindcss--callback))
   :download-server-fn (lambda (client callback error-callback update?)
                         (when lsp-tailwindcss-auto-install-server


### PR DESCRIPTION
I need to test this, but according to the [lsp-mode documentation](https://emacs-lsp.github.io/lsp-mode/page/faq/) this allows two servers to start together.

> **I have multiple language servers registered for language FOO. Which one will be used when opening a project?**
>
> The one with highest priority wins. lsp-clients.el predefined servers have priority -1, lower than external packages (priority 0 if unspecified). If a server is registered with :add-on? flag set to t it will be started in parallel to the other servers that are registered for the current mode.