### PR TITLE
tests: Setup node is no longer required

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         emacs-version:
           - 26.3
           - 27.2
-          - 28.1
+          - 28.2
           - snapshot
 
     steps:
@@ -25,10 +25,6 @@ jobs:
     - uses: jcs090218/setup-emacs@master
       with:
         version: ${{ matrix.emacs-version }}
-
-    - uses: actions/setup-node@v2
-      with:
-        node-version: '16'
 
     - uses: emacs-eask/setup-eask@master
       with:


### PR DESCRIPTION
This is no longer needed for [setup-eask](https://github.com/emacs-eask/setup-eask).