### PR TITLE
feat: bump server version to 0.9.7

### DIFF
--- a/lsp-tailwindcss.el
+++ b/lsp-tailwindcss.el
@@ -40,7 +40,7 @@
   :type 'boolean
   :group 'lsp-tailwindcss)
 
-(defcustom lsp-tailwindcss-server-version "0.9.1"
+(defcustom lsp-tailwindcss-server-version "0.9.7"
   "Specify the version of tailwindcss intellisence."
   :type 'string
   :group 'lsp-tailwindcss)


### PR DESCRIPTION
Version 0.9.7 fixes https://github.com/tailwindlabs/tailwindcss-intellisense/issues/701, which caused the language server to monitor all directories (even up to "/"), causing problems for me and other Emacs users as detailed in the issue, even stopping the language server from working entirely.