### PR TITLE
Allow for TS config file as per new release of tailwind v3.3

### DIFF
--- a/lsp-tailwindcss.el
+++ b/lsp-tailwindcss.el
@@ -294,8 +294,9 @@ see `lsp-tailwindcss-skip-config-check'"
       (file-exists-p (f-join (lsp-workspace-root) "config" "tailwind.config.js"))
       (file-exists-p (f-join (lsp-workspace-root) "assets" "tailwind.config.js"))
       (locate-dominating-file (buffer-file-name) "tailwind.config.js")
+
       (file-exists-p (f-join (lsp-workspace-root) "tailwind.config.cjs"))
-      (file-exists-p (f-join (lsp-workspace-root) "config" "tailwind.config.js"))
+      (file-exists-p (f-join (lsp-workspace-root) "config" "tailwind.config.cjs"))
       (file-exists-p (f-join (lsp-workspace-root) "assets" "tailwind.config.cjs"))
       (locate-dominating-file (buffer-file-name) "tailwind.config.cjs"))
 

--- a/lsp-tailwindcss.el
+++ b/lsp-tailwindcss.el
@@ -298,12 +298,12 @@ see `lsp-tailwindcss-skip-config-check'"
       (file-exists-p (f-join (lsp-workspace-root) "tailwind.config.cjs"))
       (file-exists-p (f-join (lsp-workspace-root) "config" "tailwind.config.cjs"))
       (file-exists-p (f-join (lsp-workspace-root) "assets" "tailwind.config.cjs"))
-      (locate-dominating-file (buffer-file-name) "tailwind.config.cjs"))
+      (locate-dominating-file (buffer-file-name) "tailwind.config.cjs")
 
      (file-exists-p (f-join (lsp-workspace-root) "tailwind.config.ts"))
       (file-exists-p (f-join (lsp-workspace-root) "config" "tailwind.config.ts"))
       (file-exists-p (f-join (lsp-workspace-root) "assets" "tailwind.config.ts"))
-      (locate-dominating-file (buffer-file-name) "tailwind.config.ts"))
+      (locate-dominating-file (buffer-file-name) "tailwind.config.ts")))
 
 (defun lsp-tailwindcss--activate-p (&rest _args)
   "Check if tailwindcss language server can/should start."

--- a/lsp-tailwindcss.el
+++ b/lsp-tailwindcss.el
@@ -297,7 +297,12 @@ see `lsp-tailwindcss-skip-config-check'"
       (file-exists-p (f-join (lsp-workspace-root) "tailwind.config.cjs"))
       (file-exists-p (f-join (lsp-workspace-root) "config" "tailwind.config.js"))
       (file-exists-p (f-join (lsp-workspace-root) "assets" "tailwind.config.cjs"))
-      (locate-dominating-file (buffer-file-name) "tailwind.config.cjs")))
+      (locate-dominating-file (buffer-file-name) "tailwind.config.cjs"))
+
+     (file-exists-p (f-join (lsp-workspace-root) "tailwind.config.ts"))
+      (file-exists-p (f-join (lsp-workspace-root) "config" "tailwind.config.ts"))
+      (file-exists-p (f-join (lsp-workspace-root) "assets" "tailwind.config.ts"))
+      (locate-dominating-file (buffer-file-name) "tailwind.config.ts"))
 
 (defun lsp-tailwindcss--activate-p (&rest _args)
   "Check if tailwindcss language server can/should start."


### PR DESCRIPTION
In the new release of Tailwind, support for typescript config files was added ( https://tailwindcss.com/blog/tailwindcss-v3-3#esm-and-typescript-support ). This PR adds checks for presence of those .ts files, and fixes what I believed to be a typo in checking for .cjs config files. 