### PR TITLE
Extra command line arguments for `rustywind`.

### DIFF
--- a/Eask
+++ b/Eask
@@ -1,5 +1,5 @@
 (package "lsp-tailwindcss"
-         "0.2"
+         "0.4"
          "A lsp-mode client for tailwindcss")
 
 (website-url "https://github.com/merrickluo/lsp-tailwindcss")

--- a/lsp-tailwindcss.el
+++ b/lsp-tailwindcss.el
@@ -4,7 +4,7 @@
 
 ;; Author: A.I. <merrick@luois.me>
 ;; Keywords: language tools
-;; Version: 0.2
+;; Version: 0.4
 ;; Package-Requires: ((lsp-mode "7.1") (f "0.20.0") (emacs "26.1"))
 ;; Keywords: tailwindcss
 ;; URL: https://github.com/merrickluo/lsp-tailwindcss
@@ -57,6 +57,12 @@
   :group 'lsp-tailwindcss
   :package-version '(lsp-tailwindcss . "0.3"))
 
+(defcustom lsp-tailwindcss-rustywind-extra-args nil
+  "[Experimental] Extra arguments to use when invoking rustywind."
+  :type 'list
+  :group 'lsp-tailwindcss
+  :package-version '(lsp-tailwindcss . "0.4"))
+
 (defcustom lsp-tailwindcss-skip-config-check nil
   "Force skip config file check.
 Only use it when your config file are in unconventional location
@@ -81,7 +87,7 @@ This is an *experimental* feature, please be careful when use."
             (widen)
             (write-region nil nil tmpfile)
 
-            (let ((rustywind-args (list "--write" (file-local-name tmpfile))))
+            (let ((rustywind-args (append (list "--write" (file-local-name tmpfile)) lsp-tailwindcss-rustywind-extra-args)))
               (when (zerop (apply #'process-file lsp-tailwindcss-rustywind-command nil nil nil rustywind-args))
                 (insert-file-contents tmpfile nil nil nil t))))
 


### PR DESCRIPTION
For certain setups being able to configure how `rustywind` is being run. 

In my case, I am working on a Ruby On Rails project. The template building functions take html classes as `class: "classes"` which `rustywind` ignores with its default regex.

With this PR I can make my setup work like this:

![image](https://github.com/merrickluo/lsp-tailwindcss/assets/170356/ce016b63-bff7-45b2-b354-df11af2208bc)
