### PR TITLE
refactor: avoid code repetition, ease extension addition

### DIFF
--- a/lsp-tailwindcss.el
+++ b/lsp-tailwindcss.el
@@ -296,20 +296,20 @@ To keep it simple and performant,only check for conventional location.
 see `lsp-tailwindcss-skip-config-check'"
   (or lsp-tailwindcss-skip-config-check
       lsp-tailwindcss-experimental-config-file
-      (file-exists-p (f-join (lsp-workspace-root) "tailwind.config.js"))
-      (file-exists-p (f-join (lsp-workspace-root) "config" "tailwind.config.js"))
-      (file-exists-p (f-join (lsp-workspace-root) "assets" "tailwind.config.js"))
-      (locate-dominating-file (buffer-file-name) "tailwind.config.js")
-
-      (file-exists-p (f-join (lsp-workspace-root) "tailwind.config.cjs"))
-      (file-exists-p (f-join (lsp-workspace-root) "config" "tailwind.config.cjs"))
-      (file-exists-p (f-join (lsp-workspace-root) "assets" "tailwind.config.cjs"))
-      (locate-dominating-file (buffer-file-name) "tailwind.config.cjs")
-
-      (file-exists-p (f-join (lsp-workspace-root) "tailwind.config.ts"))
-      (file-exists-p (f-join (lsp-workspace-root) "config" "tailwind.config.ts"))
-      (file-exists-p (f-join (lsp-workspace-root) "assets" "tailwind.config.ts"))
-      (locate-dominating-file (buffer-file-name) "tailwind.config.ts")))
+      (let* ((root (lsp-workspace-root))
+             (directories (list root
+                                (f-join root "config")
+                                (f-join root "assets")))
+             (file-extensions '("js" "cjs" "mjs" "ts" "mts" "cts")))
+        (-reduce
+         (lambda (acc extension)
+           (let ((filename (format "tailwind.config.%s" extension)))
+             (or acc
+                 (seq-some (lambda (dir)
+                             (file-exists-p (f-join dir filename)))
+                           directories)
+                 (locate-dominating-file (buffer-file-name) filename))))
+         file-extensions))))
 
 (defun lsp-tailwindcss--activate-p (&rest _args)
   "Check if tailwindcss language server can/should start."


### PR DESCRIPTION
[Astro](https://docs.astro.build/en/guides/integrations-guide/tailwind/#configuring-tailwind) uses the `.mjs` extension for TailwindCSS by default. I have added support for this and other extensions mentioned in the documentation (mts,cts). Additionally, I refactored the code to avoid repetition. The `-reduce` function from `dash.el` is already a dependency of `lsp`, so there should be no issues using it.

