### PR TITLE
fix the projectInitialized warning.

### DIFF
--- a/lsp-tailwindcss.el
+++ b/lsp-tailwindcss.el
@@ -346,6 +346,7 @@ not work when typing \"-\" in classname."
   :add-on? lsp-tailwindcss-add-on-mode
   :initialization-options #'lsp-tailwindcss--initialization-options
   :initialized-fn #'lsp-tailwindcss--company-dash-hack
+  :notification-handlers (ht ("@/tailwindCSS/projectInitialized" #'ignore))
   :download-server-fn (lambda (_client callback error-callback _update?)
                         (lsp-package-ensure 'tailwindcss-language-server callback error-callback))))
 


### PR DESCRIPTION
When I use Tailwind CSS, every time I open a new project, a "projectInitialized" warning appears. Later, I found out that it can be ignored through this setting. Can you help me merge the code?

```
Warning (lsp-mode): Unknown notification: @/tailwindCSS/projectInitialized
```