### PR TITLE
feat: support tailwindcss v4

### DIFF
--- a/Eask
+++ b/Eask
@@ -1,5 +1,5 @@
 (package "lsp-tailwindcss"
-         "0.4"
+         "0.5"
          "A lsp-mode client for tailwindcss")
 
 (website-url "https://github.com/merrickluo/lsp-tailwindcss")

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ EASK ?= eask
 
 .PHONY: ci clean package install compile test checkdoc lint
 
-ci: clean package install compile checkdoc lint
+ci: clean package install compile checkdoc lint test
 
 package:
 	@echo "Packaging..."

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ compile:
 test:
 	@echo "Testing..."
 	$(EASK) install-deps --dev
-	$(EASK) ert ./test/*.el
+	$(EASK) test ert ./test/*.el
 
 checkdoc:
 	@echo "Run checkdoc..."

--- a/lsp-tailwindcss.el
+++ b/lsp-tailwindcss.el
@@ -30,6 +30,7 @@
 
 ;;; Code:
 (require 'lsp-mode)
+(require 'f)
 
 (defgroup lsp-tailwindcss nil
   "Adds lsp-mode support for tailwindcss."

--- a/lsp-tailwindcss.el
+++ b/lsp-tailwindcss.el
@@ -312,11 +312,30 @@ see `lsp-tailwindcss-skip-config-check'"
       (f-glob "tailwind.config.*" (lsp-workspace-root))
       (f-glob "**/tailwind.config.*" (lsp-workspace-root))))
 
+(defun lsp-tailwindcss--package-version (&optional file)
+  "Return tailwindcss version from package.json (if found) closed to FILE or current buffer file.
+Checks both \"dependencies\" and \"devDependencies\"."
+  (when-let* ((start-file (or file (buffer-file-name)))
+              (package-root (locate-dominating-file start-file "package.json"))
+              (package-file (expand-file-name "package.json" package-root)))
+    (let* ((json-object-type 'hash-table)
+           (json-array-type 'list)
+           (json-key-type 'string)
+           (data (json-read-file package-file)))
+      (or (gethash "tailwindcss" (gethash "dependencies" data (make-hash-table :test 'equal)))
+          (gethash "tailwindcss" (gethash "devDependencies" data (make-hash-table :test 'equal)))))))
+
+(defun lsp-tailwindcss--version-v4-p (&optional version)
+  "Check if tailwindcss package VERSION is v4 or above.
+Will try to lookup the version if not provided"
+  (when-let ((version (or version (lsp-tailwindcss--package-version))))
+    (string-match-p "^[~^]?\\([4-9]\\|[0-9]\\{2\\}\\)\\." version)))
+
 (defun lsp-tailwindcss--activate-p (&rest _args)
   "Check if tailwindcss language server can/should start."
   (and (lsp-workspace-root)
        (apply #'provided-mode-derived-p major-mode lsp-tailwindcss-major-modes)
-       (lsp-tailwindcss--has-config-file)))
+       (or (lsp-tailwindcss--has-config-file) (lsp-tailwindcss--version-v4-p))))
 
 (defun lsp-tailwindcss--company-dash-hack (workspace)
   "Append - to the lsp completion-trigger-characters.

--- a/test/lsp-tailwindcss-test.el
+++ b/test/lsp-tailwindcss-test.el
@@ -1,0 +1,64 @@
+(require 'ert)
+
+;; Load the file to be tested
+(load-file (expand-file-name "../lsp-tailwindcss.el" (file-name-directory (or load-file-name buffer-file-name))))
+
+(ert-deftest lsp-tailwindcss--package-version-test ()
+  "Test `lsp-tailwindcss--package-version` function."
+  (let ((temp-dir (make-temp-file "test-lsp-tailwindcss" t)))
+    (unwind-protect
+        (progn
+          ;; Test case 1: tailwindcss in dependencies
+          (let* ((package-json (expand-file-name "package.json" temp-dir))
+                 (buffer-file-name (expand-file-name "index.js" temp-dir)))
+            (with-temp-file package-json
+              (insert "{\"dependencies\": {\"tailwindcss\": \"^3.0.0\"}}"))
+            (should (string= (lsp-tailwindcss--package-version) "^3.0.0")))
+
+          ;; Test case 2: tailwindcss in devDependencies
+          (let* ((package-json (expand-file-name "package.json" temp-dir))
+                 (buffer-file-name (expand-file-name "index.js" temp-dir)))
+            (with-temp-file package-json
+              (insert "{\"devDependencies\": {\"tailwindcss\": \"~2.1.0\"}}"))
+            (should (string= (lsp-tailwindcss--package-version) "~2.1.0")))
+
+          ;; Test case 3: tailwindcss in both, dependencies is preferred
+          (let* ((package-json (expand-file-name "package.json" temp-dir))
+                 (buffer-file-name (expand-file-name "index.js" temp-dir)))
+            (with-temp-file package-json
+              (insert "{\"dependencies\": {\"tailwindcss\": \"1.0.0\"}, \"devDependencies\": {\"tailwindcss\": \"2.0.0\"}}"))
+            (should (string= (lsp-tailwindcss--package-version) "1.0.0")))
+
+          ;; Test case 4: tailwindcss not present
+          (let* ((package-json (expand-file-name "package.json" temp-dir))
+                 (buffer-file-name (expand-file-name "index.js" temp-dir)))
+            (with-temp-file package-json
+              (insert "{\"dependencies\": {\"another-package\": \"1.0.0\"}}"))
+            (should (null (lsp-tailwindcss--package-version))))
+
+          ;; Test case 5: no package.json
+          (let ((buffer-file-name (expand-file-name "index.js" (expand-file-name "foo" temp-dir))))
+            (delete-file (expand-file-name "package.json" temp-dir))
+            (should (null (lsp-tailwindcss--package-version)))))
+      (delete-directory temp-dir t))))
+
+(ert-deftest lsp-tailwindcss--version-v4-p-test ()
+  "Test `lsp-tailwindcss--version-v4-p` function."
+  ;; Versions that should be considered v4 or greater
+  (should (lsp-tailwindcss--version-v4-p "4.0.0"))
+  (should (lsp-tailwindcss--version-v4-p "4.1.2"))
+  (should (lsp-tailwindcss--version-v4-p "^4.0.0"))
+  (should (lsp-tailwindcss--version-v4-p "~4.0.0"))
+  (should (lsp-tailwindcss--version-v4-p "5.0.0"))
+  (should (lsp-tailwindcss--version-v4-p "10.0.0"))
+  (should (lsp-tailwindcss--version-v4-p "^11.2.3"))
+
+  ;; Versions that should not be considered v4
+  (should-not (lsp-tailwindcss--version-v4-p "3.0.0"))
+  (should-not (lsp-tailwindcss--version-v4-p "3.9.9"))
+  (should-not (lsp-tailwindcss--version-v4-p "^3.1.0"))
+  (should-not (lsp-tailwindcss--version-v4-p "~3.1.0"))
+  (should-not (lsp-tailwindcss--version-v4-p "0.4.0"))
+  (should-not (lsp-tailwindcss--version-v4-p "1.2.3"))
+  (should-not (lsp-tailwindcss--version-v4-p "latest"))
+  (should-not (lsp-tailwindcss--version-v4-p "next")))


### PR DESCRIPTION
support tailwindcss v4 by checking if package version is >= 4 in `package.json` and skips config file check.

closes #80 